### PR TITLE
Render missing hair and facial meshes

### DIFF
--- a/apps/frontend/src/components/Avatar.jsx
+++ b/apps/frontend/src/components/Avatar.jsx
@@ -293,6 +293,9 @@ export function Avatar(props) {
       {renderSkinnedMesh("EyeRight", "Wolf3D_Eye")}
       {renderSkinnedMesh("Wolf3D_Head", "Wolf3D_Skin")}
       {renderSkinnedMesh("Wolf3D_Teeth", "Wolf3D_Teeth")}
+      {renderSkinnedMesh("Wolf3D_Eyelashes", "Wolf3D_Eyelash")}
+      {renderSkinnedMesh("Wolf3D_Eyebrows", "Wolf3D_Eyebrow")}
+      {renderSkinnedMesh("Wolf3D_Hair", "Wolf3D_Hair")}
       {renderSkinnedMesh("Wolf3D_Glasses", "Wolf3D_Glasses")}
       {renderSkinnedMesh("Wolf3D_Headwear", "Wolf3D_Headwear")}
       {renderSkinnedMesh("Wolf3D_Body", "Wolf3D_Body")}


### PR DESCRIPTION
## Summary
- render the Ready Player Me hair, eyelashes, and eyebrow meshes so the avatar matches the source model

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e306798da48325a48e3d0346e90d0c