### PR TITLE
Fix speech audio playback by serving public audio URLs

### DIFF
--- a/apps/backend/modules/defaultMessages.mjs
+++ b/apps/backend/modules/defaultMessages.mjs
@@ -1,47 +1,72 @@
-import { audioFileToBase64, readJsonTranscript } from "../utils/files.mjs";
+import { buildAudioPublicUrl, readJsonTranscript } from "../utils/files.mjs";
 import dotenv from "dotenv";
 dotenv.config();
 
 const openAIApiKey = process.env.OPENAI_API_KEY;
 const elevenLabsApiKey = process.env.ELEVEN_LABS_API_KEY;
 
-async function sendDefaultMessages({ userMessage }) {
+const getDefaultMessage = async ({
+  text,
+  audioFile,
+  lipsyncFile,
+  facialExpression,
+  animation,
+  hostUrl,
+}) => {
+  const audioUrl = buildAudioPublicUrl({ fileName: audioFile, hostUrl });
+  if (!audioUrl) {
+    console.warn(`[DefaultMessages] Missing audio URL for file ${audioFile}`);
+  }
+  return {
+    text,
+    audioUrl,
+    lipsync: await readJsonTranscript({ fileName: lipsyncFile }),
+    facialExpression,
+    animation,
+  };
+};
+
+async function sendDefaultMessages({ userMessage, hostUrl }) {
   let messages;
   if (!userMessage) {
     messages = [
-      {
+      await getDefaultMessage({
         text: "Hey there... How was your day?",
-        audio: await audioFileToBase64({ fileName: "audios/intro_0.wav" }),
-        lipsync: await readJsonTranscript({ fileName: "audios/intro_0.json" }),
+        audioFile: "intro_0.wav",
+        lipsyncFile: "intro_0.json",
         facialExpression: "smile",
         animation: "TalkingOne",
-      },
-      {
+        hostUrl,
+      }),
+      await getDefaultMessage({
         text: "I'm Jack, your personal AI assistant. I'm here to help you with anything you need.",
-        audio: await audioFileToBase64({ fileName: "audios/intro_1.wav" }),
-        lipsync: await readJsonTranscript({ fileName: "audios/intro_1.json" }),
+        audioFile: "intro_1.wav",
+        lipsyncFile: "intro_1.json",
         facialExpression: "smile",
         animation: "TalkingTwo",
-      },
+        hostUrl,
+      }),
     ];
     return messages;
   }
   if (!elevenLabsApiKey || !openAIApiKey) {
     messages = [
-      {
+      await getDefaultMessage({
         text: "Please my friend, don't forget to add your API keys!",
-        audio: await audioFileToBase64({ fileName: "audios/api_0.wav" }),
-        lipsync: await readJsonTranscript({ fileName: "audios/api_0.json" }),
+        audioFile: "api_0.wav",
+        lipsyncFile: "api_0.json",
         facialExpression: "angry",
         animation: "TalkingThree",
-      },
-      {
+        hostUrl,
+      }),
+      await getDefaultMessage({
         text: "You don't want to ruin Jack with a crazy ChatGPT and ElevenLabs bill, right?",
-        audio: await audioFileToBase64({ fileName: "audios/api_1.wav" }),
-        lipsync: await readJsonTranscript({ fileName: "audios/api_1.json" }),
+        audioFile: "api_1.wav",
+        lipsyncFile: "api_1.json",
         facialExpression: "smile",
         animation: "Angry",
-      },
+        hostUrl,
+      }),
     ];
     return messages;
   }

--- a/apps/backend/modules/lip-sync.mjs
+++ b/apps/backend/modules/lip-sync.mjs
@@ -1,26 +1,37 @@
 import { convertTextToSpeech } from "./elevenLabs.mjs";
 import { getPhonemes } from "./rhubarbLipSync.mjs";
-import { readJsonTranscript, audioFileToBase64 } from "../utils/files.mjs";
+import {
+  readJsonTranscript,
+  ensureAudioDirectory,
+  resolveAudioPath,
+  buildAudioPublicUrl,
+} from "../utils/files.mjs";
 
 const MAX_RETRIES = 10;
 const RETRY_DELAY = 0;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const lipSync = async ({ messages }) => {
+const lipSync = async ({ messages, hostUrl }) => {
+  await ensureAudioDirectory();
+
   await Promise.all(
     messages.map(async (message, index) => {
-      const fileName = `audios/message_${index}.mp3`;
+      const fileName = `message_${index}.mp3`;
+      const filePath = resolveAudioPath(fileName);
 
       for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
         try {
-          await convertTextToSpeech({ text: message.text, fileName });
+          console.log(`[Audio] Generating speech for message ${index} -> ${filePath}`);
+          await convertTextToSpeech({ text: message.text, fileName: filePath });
+          console.log(`[Audio] Speech synthesis completed for message ${index}`);
           await delay(RETRY_DELAY);
           break;
         } catch (error) {
           if (error.response && error.response.status === 429 && attempt < MAX_RETRIES - 1) {
             await delay(RETRY_DELAY);
           } else {
+            console.error(`[Audio] Failed to synthesize audio for message ${index}:`, error);
             throw error;
           }
         }
@@ -31,12 +42,22 @@ const lipSync = async ({ messages }) => {
 
   await Promise.all(
     messages.map(async (message, index) => {
-      const fileName = `audios/message_${index}.mp3`;
+      const fileName = `message_${index}.mp3`;
+      const filePath = resolveAudioPath(fileName);
 
       try {
-        await getPhonemes({ message: index });
-        message.audio = await audioFileToBase64({ fileName });
-        message.lipsync = await readJsonTranscript({ fileName: `audios/message_${index}.json` });
+        const transcriptPath = await getPhonemes({ sourceFilePath: filePath });
+        const publicUrl = buildAudioPublicUrl({ fileName, hostUrl });
+        message.audioUrl = publicUrl ? `${publicUrl}?v=${Date.now()}` : null;
+        if (!message.audioUrl) {
+          console.warn(`[Audio] Missing audio URL for message ${index}`);
+        }
+        message.lipsync = transcriptPath
+          ? await readJsonTranscript({ fileName: transcriptPath })
+          : undefined;
+        if (!message.lipsync) {
+          console.warn(`[LipSync] Missing lip sync data for message ${index}`);
+        }
       } catch (error) {
         console.error(`Error while getting phonemes for message ${index}:`, error);
       }

--- a/apps/backend/utils/files.mjs
+++ b/apps/backend/utils/files.mjs
@@ -1,5 +1,7 @@
 import { exec } from "child_process";
 import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const execCommand = ({ command }) => {
   return new Promise((resolve, reject) => {
@@ -10,14 +12,43 @@ const execCommand = ({ command }) => {
   });
 };
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const AUDIO_DIRECTORY = path.resolve(__dirname, "../audios");
+const AUDIO_PUBLIC_ROUTE = "/audios";
+
+const ensureAudioDirectory = async () => {
+  await fs.mkdir(AUDIO_DIRECTORY, { recursive: true });
+};
+
+const resolveAudioPath = (fileName) => {
+  if (!fileName) {
+    return AUDIO_DIRECTORY;
+  }
+  return path.isAbsolute(fileName) ? fileName : path.join(AUDIO_DIRECTORY, fileName);
+};
+
+const buildAudioPublicUrl = ({ fileName, hostUrl }) => {
+  if (!fileName) {
+    return null;
+  }
+  const base = hostUrl ? hostUrl.replace(/\/$/, "") : "";
+  const route = fileName.startsWith("/") ? fileName : `${AUDIO_PUBLIC_ROUTE}/${fileName}`;
+  return `${base}${route}`;
+};
+
 const readJsonTranscript = async ({ fileName }) => {
-  const data = await fs.readFile(fileName, "utf8");
+  const targetPath = resolveAudioPath(fileName);
+  const data = await fs.readFile(targetPath, "utf8");
   return JSON.parse(data);
 };
 
-const audioFileToBase64 = async ({ fileName }) => {
-  const data = await fs.readFile(fileName);
-  return data.toString("base64");
+export {
+  execCommand,
+  readJsonTranscript,
+  ensureAudioDirectory,
+  resolveAudioPath,
+  buildAudioPublicUrl,
+  AUDIO_DIRECTORY,
+  AUDIO_PUBLIC_ROUTE,
 };
-
-export { execCommand, readJsonTranscript, audioFileToBase64 };

--- a/apps/frontend/src/hooks/useSpeech.jsx
+++ b/apps/frontend/src/hooks/useSpeech.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
 
 const backendUrl = "http://localhost:3000";
 
@@ -10,6 +10,7 @@ export const SpeechProvider = ({ children }) => {
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState();
   const [loading, setLoading] = useState(false);
+  const [currentAudio, setCurrentAudio] = useState(null);
 
   let chunks = [];
 
@@ -36,9 +37,17 @@ export const SpeechProvider = ({ children }) => {
           body: JSON.stringify({ audio: base64Audio }),
         });
         const response = (await data.json()).messages;
-        setMessages((messages) => [...messages, ...response]);
+        if (!Array.isArray(response) || response.length === 0) {
+          console.warn("[Speech] Received empty response from STS endpoint.");
+        }
+        response?.forEach((msg, index) => {
+          if (!msg?.audioUrl) {
+            console.warn(`[Speech] Missing audio URL in STS response (index ${index}).`, msg);
+          }
+        });
+        setMessages((messages) => [...messages, ...(response || [])]);
       } catch (error) {
-        console.error(error);
+        console.error("[Speech] Error sending STS request:", error);
       } finally {
         setLoading(false);
       }
@@ -93,17 +102,26 @@ export const SpeechProvider = ({ children }) => {
         body: JSON.stringify({ message }),
       });
       const response = (await data.json()).messages;
-      setMessages((messages) => [...messages, ...response]);
+      if (!Array.isArray(response) || response.length === 0) {
+        console.warn("[Speech] Received empty response from TTS endpoint.");
+      }
+      response?.forEach((msg, index) => {
+        if (!msg?.audioUrl) {
+          console.warn(`[Speech] Missing audio URL in TTS response (index ${index}).`, msg);
+        }
+      });
+      setMessages((messages) => [...messages, ...(response || [])]);
     } catch (error) {
-      console.error(error);
+      console.error("[Speech] Error sending TTS request:", error);
     } finally {
       setLoading(false);
     }
   };
 
-  const onMessagePlayed = () => {
+  const onMessagePlayed = useCallback(() => {
     setMessages((messages) => messages.slice(1));
-  };
+    setCurrentAudio(null);
+  }, []);
 
   useEffect(() => {
     if (messages.length > 0) {
@@ -112,6 +130,71 @@ export const SpeechProvider = ({ children }) => {
       setMessage(null);
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (!message) {
+      setCurrentAudio(null);
+      return;
+    }
+
+    const buildPlayableUrl = (audioUrl) => {
+      if (!audioUrl) {
+        return null;
+      }
+      if (/^https?:\/\//i.test(audioUrl)) {
+        return audioUrl;
+      }
+      const normalizedBackendUrl = backendUrl.replace(/\/$/, "");
+      const normalizedAudioUrl = audioUrl.startsWith("/") ? audioUrl : `/${audioUrl}`;
+      return `${normalizedBackendUrl}${normalizedAudioUrl}`;
+    };
+
+    const playableUrl = buildPlayableUrl(message.audioUrl);
+
+    if (!playableUrl) {
+      console.warn("[Speech] No playable audio URL provided for message.", message);
+      onMessagePlayed();
+      return;
+    }
+
+    console.log(`[Speech] Preparing audio playback for ${playableUrl}`);
+    const audio = new Audio(playableUrl);
+    audio.crossOrigin = "anonymous";
+
+    const handleEnded = () => {
+      console.log(`[Speech] Playback ended for ${playableUrl}`);
+      onMessagePlayed();
+    };
+
+    const handleError = (event) => {
+      console.error(`[Speech] Playback error for ${playableUrl}`, event);
+      onMessagePlayed();
+    };
+
+    audio.addEventListener("ended", handleEnded);
+    audio.addEventListener("error", handleError);
+
+    const playPromise = audio.play();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise
+        .then(() => console.log(`[Speech] Playback started for ${playableUrl}`))
+        .catch((error) => {
+          console.error(`[Speech] Playback failed for ${playableUrl}`, error);
+          onMessagePlayed();
+        });
+    } else {
+      console.log(`[Speech] Playback started for ${playableUrl}`);
+    }
+
+    setCurrentAudio(audio);
+
+    return () => {
+      console.log(`[Speech] Cleaning up audio for ${playableUrl}`);
+      audio.removeEventListener("ended", handleEnded);
+      audio.removeEventListener("error", handleError);
+      audio.pause();
+    };
+  }, [message, onMessagePlayed]);
 
   return (
     <SpeechContext.Provider
@@ -123,6 +206,7 @@ export const SpeechProvider = ({ children }) => {
         message,
         onMessagePlayed,
         loading,
+        currentAudio,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- expose ElevenLabs output under /audios with static hosting, host resolution, and updated default message URLs
- adjust the lip sync pipeline to save files in the shared audio directory, build public URLs, and log synthesis/phoneme steps
- update the speech hook and avatar to stream audio from the new URLs with playback/error diagnostics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30fe5bea08325bebfd105f7c2d7fc